### PR TITLE
Enroute will require with consistent casings on Win32 (fix for issue #1)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,7 +6,7 @@
     },
     "rules": {
         // possible errors
-        "comma-dangle": [ 2 ],
+        //"comma-dangle": [ 2 ],
         "no-cond-assign": [ 2 ],
         "no-console": [ 2 ],
         "no-constant-condition": [ 2 ],

--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,3 @@ npm-debug.log
 *.*~
 .idea
 .oracle_jre_usage
-.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ npm-debug.log
 *.*~
 .idea
 .oracle_jre_usage
+.vscode/

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,6 +17,25 @@ var shell = require('shelljs');
 var restify = require('restify');
 
 /**
+ * checks if the path is device rooted, that is, if it has [drive letter]:\ at its beggining.
+ * @private
+ * @param {String} fpath
+ *      The file path to check
+ * @returns {Boolean}
+ *      Whether the path is rooted or not.
+ */
+function isWin32DeviceRoot(fpath) {
+    // Only for win32
+    if (process.platform !== 'win32') {
+        return false;
+    }
+
+    // Any drive letter followed by :\
+    var deviceRoot = /^[A-Za-z]:\\/;
+    return deviceRoot.test(fpath);
+}
+
+/**
  * read file synchronously, throw Verror
  * on error, log the error message
  * @public
@@ -147,11 +166,15 @@ function createRoute(options, cb) {
                         scriptFpath));
                 } else {
                     scriptFpath = path.resolve(scriptFpath);
+                    // make sure the path casing obeys the casing of the parent
+                    if (isWin32DeviceRoot(scriptFpath) && scriptFpath.substr(0, 2).toLowerCase() === module.filename.substr(0, 2).toLowerCase()) {
+                        scriptFpath = module.filename.substr(0, 2) + scriptFpath.substr(2);
+                    }
                 }
                 //routeKey = routePath + '}' + method;
 
                 if (typeof routelist[routePath] !== 'undefined') {
-                    throw new Error('Route path exist' + rpath
+                    throw new Error('Route path exist' + rpath 
                         + ' method ' + method);
                 }
 


### PR DESCRIPTION
As I explained on issue #1, I'm wrote code to defensively guard against path.resolve returning a different casing on Win32 when Node was started with a upper case. This is due to [Node's issue #6978](https://github.com/nodejs/node/issues/6978) on Windows, but for the moment, the workaround has to be done here. 
