### PR TITLE
use cause and not err when instantiating verrors

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -46,7 +46,7 @@ function install(opts, cb) {
                         function (err, data) {
                         if (err) {
                             return cb1(new verror.VError({
-                                err: err,
+                                cause: err,
                                 info: {
                                     route: routeName,
                                     method: method,
@@ -66,7 +66,7 @@ function install(opts, cb) {
                             };
                         } catch (e) {
                             return cb1(new verror.VError({
-                                err: e,
+                                cause: e,
                                 info: {
                                     func: data,
                                     route: routeName,

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -69,7 +69,7 @@ function parse(opts, cb) {
                 fs.readFile(opts.configPath, 'utf8', function (err, config) {
                     if (err) {
                         cb1(new verror.VError({
-                            err: err,
+                            cause: err,
                             info: {
                                 fileName: opts.configPath
                             }
@@ -80,7 +80,7 @@ function parse(opts, cb) {
                             cb1();
                         } catch (e) {
                             cb1(new verror.VError({
-                                err: err,
+                                cause: err,
                                 info: {
                                     fileName: opts.configPath,
                                     fileContents: config

--- a/test/install.js
+++ b/test/install.js
@@ -100,6 +100,7 @@ describe('enroute-install', function () {
         } catch (exception) {
             assert.isNotNull(exception, 'Exception should exist');
             assert.equal(exception.actual, 'must specify opts.basePath');
+            assert.isOk(exception.stack);
             done();
         }
     });
@@ -115,6 +116,7 @@ describe('enroute-install', function () {
             basePath: BASEPATH
         }, function (err) {
             assert.isOk(err);
+            assert.isOk(err.stack);
             return done();
         });
     });
@@ -130,6 +132,7 @@ describe('enroute-install', function () {
             basePath: BASEPATH
         }, function (err) {
             assert.isOk(err);
+            assert.isOk(err.stack);
             return done();
         });
 


### PR DESCRIPTION
cc: @DonutEspresso @rajatkumar use `cause` instead of `err` when instantiating verrors so that we capture the stacktrace.