### PR TITLE
Use Require and not Eval to import routes

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var fs = require('fs');
 var path = require('path');
 
 var _ = require('lodash');

--- a/lib/install.js
+++ b/lib/install.js
@@ -40,54 +40,39 @@ function install(opts, cb) {
                     barrier.start(routeName + method);
                     // resolve to the correct file
                     var sourceFile = path.resolve(opts.basePath, src.source);
-                    // use the resolved file path
-                    fs.readFile(sourceFile,
-                        {encoding: 'utf8'},
-                        function (err, data) {
-                        if (err) {
-                            return cb1(new verror.VError({
-                                cause: err,
-                                info: {
-                                    route: routeName,
-                                    method: method,
-                                    fileName: src.source
-                                }
-                            }, 'unable to read route source from disk'));
-                        }
-                        var route;
+                    var route;
 
-                        try {
-                            route = {
-                                name: routeName,
-                                method: method,
-                                /* eslint-disable no-eval */
-                                func: eval(data)
-                                /* eslint-enable no-eval */
-                            };
-                        } catch (e) {
-                            return cb1(new verror.VError({
-                                cause: e,
-                                info: {
-                                    func: data,
-                                    route: routeName,
-                                    method: method
-                                }
-                            }, 'route function is invalid'));
-                        }
-                        // if HTTP method is 'delete', since restify uses 'del'
-                        // instead of 'delete', change it to 'del'
-                        if (route.method === 'delete') {
-                            route.method = 'del';
-                        }
-                        // if HTTP method is 'options', since restify uses
-                        // 'opts' instead of 'options', change it to 'opts'
-                        if (route.method === 'options') {
-                            route.method = 'opts';
-                        }
-                        ctx.routes.push(route);
-                        barrier.done(routeName + method);
-                        return null;
-                    });
+                    try {
+                        route = {
+                            name: routeName,
+                            method: method,
+                            /* eslint-disable no-eval */
+                            func: require(sourceFile)
+                            /* eslint-enable no-eval */
+                        };
+                    } catch (e) {
+                        return cb1(new verror.VError({
+                            cause: e,
+                            info: {
+                                file: sourceFile,
+                                route: routeName,
+                                method: method
+                            }
+                        }, 'route function is invalid'));
+                    }
+                    // if HTTP method is 'delete', since restify uses 'del'
+                    // instead of 'delete', change it to 'del'
+                    if (route.method === 'delete') {
+                        route.method = 'del';
+                    }
+                    // if HTTP method is 'options', since restify uses
+                    // 'opts' instead of 'options', change it to 'opts'
+                    if (route.method === 'options') {
+                        route.method = 'opts';
+                    }
+                    ctx.routes.push(route);
+                    barrier.done(routeName + method);
+                    return null;
                 });
             });
         },

--- a/lib/install.js
+++ b/lib/install.js
@@ -45,9 +45,7 @@ function install(opts, cb) {
                         route = {
                             name: routeName,
                             method: method,
-                            /* eslint-disable no-eval */
                             func: require(sourceFile)
-                            /* eslint-enable no-eval */
                         };
                     } catch (e) {
                         return cb1(new verror.VError({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restify-enroute",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "main": "./lib/index.js",
   "description": "Config driven restify route creation",
   "homepage": "http://www.restify.com",


### PR DESCRIPTION
This PR uses require to import the routes, which makes the routes visible to the debugger.