### PR TITLE
ES6 friendly

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -42,10 +42,11 @@ function install(opts, cb) {
                     var route;
 
                     try {
+                        var func = require(sourceFile)
                         route = {
                             name: routeName,
                             method: method,
-                            func: require(sourceFile)
+                            func: typeof func === 'function' ? func : func[Object.keys(func)[0]]
                         };
                     } catch (e) {
                         return cb1(new verror.VError({


### PR DESCRIPTION
Old way: `module.exports = function handler(req, res, next) {`
New ways:
`export default (req, res, next) => {`
`export function handler(req, res, next) {`
`export const handler = (req, res, next) => {`