### PR TITLE
Exclude node_modules from hot reloading

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -157,9 +157,12 @@ function reloadProxy(opts, cb) {
     assert.string(opts.sourceFile, 'opts.sourceFile');
     assert.func(cb, 'cb');
 
-    // clear require cache for code loaded from a specific base dir
+    // clear require cache for code loaded from a specific base dir.
+    // node_modules is explicitly excluded
+    // because it doesn't work with all modules.
     Object.keys(require.cache).forEach(function (cacheKey) {
-        if (cacheKey.indexOf(opts.basePath) !== -1) {
+        if (cacheKey.indexOf('node_modules') === -1
+            && cacheKey.indexOf(opts.basePath) !== -1) {
             delete require.cache[cacheKey];
         }
     });


### PR DESCRIPTION
Exclude node_modules from hot reloading, because it doesn't work with all modules. Specifically modules with platform bindings such as grpc seem to be problematic.

Probably add explicit includes/excludes later

PM (edit): native modules cannot be re-registered in Node