### PR TITLE
fix: don't obscure errors when multiple routes fail to import

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,7 @@
     "env": {
         "browser": false,
         "node": true,
-        "es6": false
+        "es6": true
     },
     "rules": {
         // possible errors

--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,7 @@ LIB_FILES	:= $(ROOT)/lib
 TEST_FILES	:= $(ROOT)/test
 COVERAGE_FILES	:= $(ROOT)/coverage
 LCOV	:= $(ROOT)/coverage/lcov.info
-SRCS	:= $(shell find $(LIB_FILES) $(TEST_FILES) -name '*.js' -type f \
-	-not \( -path './node_modules/*' -prune \))
+SRCS	:= $(shell find $(LIB_FILES) $(TEST_FILES) -name '*.js' -type f -not -name 'syntaxError.js' )
 
 #
 # Targets

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,7 @@ module.exports = {
      * exports
      *
      * @param {object} opts Options object.
-     * @param {string} [opts.config] The POJO of the config you want to
+     * @param {object} [opts.config] The POJO of the config you want to
      * validate.
      * @param {string} [opts.configPath] The path to the data on disk to
      * validate.

--- a/lib/install.js
+++ b/lib/install.js
@@ -2,7 +2,6 @@
 
 var path = require('path');
 
-var _ = require('lodash');
 var assert = require('assert-plus');
 var vasync = require('vasync');
 var verror = require('verror');
@@ -63,13 +62,15 @@ function install(opts, cb) {
             }
 
             // go through each of the route names
-            _.forEach(opts.enroute.routes, function (methods, routeName) {
+            for (const [routeName, methods]
+                of Object.entries(opts.enroute.routes)
+            ) {
                 // go through each of the HTTP methods
-                _.forEach(methods, function (src, method) {
+                for (const [method, src] of Object.entries(methods)) {
                     barrier.start(routeName + method);
                     // resolve to the correct file
-                    var sourceFile = path.resolve(opts.basePath, src.source);
-                    var route;
+                    const sourceFile = path.resolve(opts.basePath, src.source);
+                    let route;
 
                     try {
                         var func = (opts.hotReload) ?
@@ -114,18 +115,18 @@ function install(opts, cb) {
                     }
                     ctx.routes.push(route);
                     barrier.done(routeName + method);
-                    return null;
-                });
-            });
+                }
+            }
+            return null; // cb1() is called in 'drain' event above
         },
         function installRoutes(ctx, cb1) {
-            _.forEach(ctx.routes, function (route) {
+            for (const route of ctx.routes) {
                 var routePath = typeof route.name === 'string' &&
                      route.name[0] === '/'
                     ? route.name
                     : '/' + route.name;
                 opts.server[route.method](routePath, route.func);
-            });
+            }
 
             return cb1();
         }

--- a/test/etc/notAFunction.js
+++ b/test/etc/notAFunction.js
@@ -1,1 +1,0 @@
-// n.b. this is meant to be empty

--- a/test/etc/syntaxError.js
+++ b/test/etc/syntaxError.js
@@ -1,0 +1,9 @@
+'use strict'
+
+some invalid syntax
+
+module.exports = function syntaxErrorGet(req, res, next) {
+  res.header('method', 'get');
+  res.send(200);
+  next();
+};


### PR DESCRIPTION
The newer version of `vasync` (upgraded in this lib in 6.1.1) has a worse error message when a pipeline callback is invoked multiple times. Now it gives the obscure `AssertionError: idx should be equal to ndone`.

The reason the pipeline callback was being called multiple times was due to `install` logic doing route handler imports in a `lodash.forEach` loop. The logic would catch the exception, then `return cb1(err)`, but the return was only for the current `forEach` iteration, so was equivalent to a `continue` instead of terminating with an error.

So if multiple route source files failed to import, we would end up calling the pipeline callback with an error multiple times. The `vasync` assertion error would then obscure the original error, making these much harder to debug. We'd commonly see this if multiple route handlers both depended on some common helper file which was missing or had an error in it.

This replaces the `forEach` loops with `for ... of` loops, so that when it returns and calls the pipeline callback, it now will terminate the loop.

This also fixes some tests that were not testing what they claimed to. The tests were failing because the config was malformed, not because of the intended error states. I deleted one test because this lib actually does not even throw an error in that case.